### PR TITLE
Unix support for building the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,59 +8,65 @@ set(CMAKE_AUTOUIC ON)
 
 set(CMAKE_PREFIX_PATH "C:\\Qt\\6.2.4\\mingw_64\\lib\\cmake")
 
+if(UNIX)
+    set(CMAKE_PREFIX_PATH "~/Qt/6.2.4/gcc_64/lib/cmake")
+endif(UNIX)
+
 find_package(Qt6 COMPONENTS
-        Core
-        Gui
-        Widgets
-        REQUIRED)
+    Core
+    Gui
+    Widgets
+    REQUIRED)
 
 add_executable(a5_5_913_Goia_Alexia
-        "source files/main.cpp"
-        "header files/DynamicArray.h"
-        "source files/service.cpp"
-        "header files/service.h"
-        "source files/repo.cpp"
-        "header files/repo.h"
-        "source files/tutorial.cpp"
-        "header files/tutorial.h"
-        "source files/ui.cpp"
-        "header files/ui.h"
-        "source files/tests.cpp"
-        "header files/tests.h"
-        "header files/handlers.h"
-        "source files/handlers.cpp"
-        "header files/gui.h"
-       "source files/gui.cpp")
+    "source files/main.cpp"
+    "header files/DynamicArray.h"
+    "source files/service.cpp"
+    "header files/service.h"
+    "source files/repo.cpp"
+    "header files/repo.h"
+    "source files/tutorial.cpp"
+    "header files/tutorial.h"
+    "source files/ui.cpp"
+    "header files/ui.h"
+    "source files/tests.cpp"
+    "header files/tests.h"
+    "header files/handlers.h"
+    "source files/handlers.cpp"
+    "header files/gui.h"
+    "source files/gui.cpp")
 target_link_libraries(a5_5_913_Goia_Alexia
-        Qt::Core
-        Qt::Gui
-        Qt::Widgets
-        )
+    Qt::Core
+    Qt::Gui
+    Qt::Widgets
+)
 
-
-
-if (WIN32)
+if(WIN32)
     set(DEBUG_SUFFIX)
     set(QT_INSTALL_PATH "${CMAKE_PREFIX_PATH}")
-    if (NOT EXISTS "${QT_INSTALL_PATH}/bin")
+
+    if(NOT EXISTS "${QT_INSTALL_PATH}/bin")
         set(QT_INSTALL_PATH "${QT_INSTALL_PATH}/..")
-        if (NOT EXISTS "${QT_INSTALL_PATH}/bin")
+
+        if(NOT EXISTS "${QT_INSTALL_PATH}/bin")
             set(QT_INSTALL_PATH "${QT_INSTALL_PATH}/..")
-        endif ()
-    endif ()
-    if (EXISTS "${QT_INSTALL_PATH}/plugins/platforms/qwindows${DEBUG_SUFFIX}.dll")
+        endif()
+    endif()
+
+    if(EXISTS "${QT_INSTALL_PATH}/plugins/platforms/qwindows${DEBUG_SUFFIX}.dll")
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E make_directory
-                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/plugins/platforms/")
+            COMMAND ${CMAKE_COMMAND} -E make_directory
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}>/plugins/platforms/")
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy
-                "${QT_INSTALL_PATH}/plugins/platforms/qwindows${DEBUG_SUFFIX}.dll"
-                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/plugins/platforms/")
-    endif ()
-    foreach (QT_LIB Core Gui Widgets)
+            COMMAND ${CMAKE_COMMAND} -E copy
+            "${QT_INSTALL_PATH}/plugins/platforms/qwindows${DEBUG_SUFFIX}.dll"
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}>/plugins/platforms/")
+    endif()
+
+    foreach(QT_LIB Core Gui Widgets)
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy
-                "${QT_INSTALL_PATH}/bin/Qt6${QT_LIB}${DEBUG_SUFFIX}.dll"
-                "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
-    endforeach (QT_LIB)
-endif ()
+            COMMAND ${CMAKE_COMMAND} -E copy
+            "${QT_INSTALL_PATH}/bin/Qt6${QT_LIB}${DEBUG_SUFFIX}.dll"
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+    endforeach(QT_LIB)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Qt6 COMPONENTS
 
 add_executable(a5_5_913_Goia_Alexia
     "source files/main.cpp"
-    "header files/DynamicArray.h"
+    "header files/dynamicArray.h"
     "source files/service.cpp"
     "header files/service.h"
     "source files/repo.cpp"


### PR DESCRIPTION
Hi I am a big fan!

I added two changes to the CMakeLists.txt, so it can be build for UNIX systems as well.

1. If you used the basic installation of Qt 6.2.4 then the provided path is used for cmake files
2. The header file dynamicArray.h was misspelled in the CMakeLists.txt as DynamicArray.h

Changing these I was able to build the project.
To be fair when I wanted to run the binary it gave me this error. I can only assume this is an uncaught error. I think I am missing the required files for the Repository to work. 

![image](https://user-images.githubusercontent.com/91517310/184670576-b44bc9ec-0665-49d5-9f69-f2d49993d289.png)

Nevertheless keep up the good work!
A happy supporter!